### PR TITLE
Remove suggestion to specify num cpu

### DIFF
--- a/src/ccsfm/forward_models/run_cirrus.py
+++ b/src/ccsfm/forward_models/run_cirrus.py
@@ -72,6 +72,6 @@ class Cirrus(ForwardModelStepPlugin):
             examples="""
             FORWARD_MODEL CIRRUS(<CASE>="casename.in")
 
-            FORWARD_MODEL CIRRUS(<CASE>="casename.in", <VERSION>=x.x, <NUM_CPU>=4)
+            FORWARD_MODEL CIRRUS(<CASE>="casename.in", <VERSION>=x.x)
             """,
         )


### PR DESCRIPTION
By default, as we use <NUM_CPU> in the command, the NUM_CPU from the ert user config will be used. It is not necessary for the user to also specify it.

This does not stop the user from adding it, hence overriding the NUM cpu from Ert is still possible.