### PR TITLE
Validate CIRRUS arguments pre-experiment

### DIFF
--- a/src/ccsfm/forward_models/run_cirrus.py
+++ b/src/ccsfm/forward_models/run_cirrus.py
@@ -5,6 +5,7 @@ import os
 from ert import (
     ForwardModelStepDocumentation,
     ForwardModelStepPlugin,
+    ForwardModelStepWarning,
     ForwardModelStepJSON,
     ForwardModelStepValidationError,
 )
@@ -42,13 +43,40 @@ class Cirrus(ForwardModelStepPlugin):
         )
 
     def validate_pre_experiment(self, fm_step_json: ForwardModelStepJSON) -> None:
-        version_idx = fm_step_json["argList"].index("-v") + 1
+        PROTECTED_ARGUMENT = ["<NUM_CPU>"]
+        REQUIRED_ARGUMENTS = ["<CASE>"]
+        OPTIONAL_ARGUMENTS = ["<VERSION>"]
 
+        if protected_arguments_used := [
+            arg for arg in self.private_args if arg in PROTECTED_ARGUMENT
+        ]:
+            raise ForwardModelStepValidationError(
+                f"CIRRUS forward model will use {', '.join(protected_arguments_used)} as set in ert config. It is not allowed to modify"
+            )
+
+        # If an argument exists in fm_step_json['arglist'] it means it has not been substituted with a defined variable from ert config
+        # We check that a required argument must either be in private_args or not present in fm_step_json['arglist']
+        if missing_required_arg := [
+            arg for arg in REQUIRED_ARGUMENTS if arg not in self.private_args and arg in fm_step_json["argList"]
+        ]:
+            raise ForwardModelStepValidationError(
+                f"Missing required arguments: {', '.join(missing_required_arg)}"
+            )
+
+        if unrecognised_arguments := [
+            arg
+            for arg in self.private_args
+            if arg not in REQUIRED_ARGUMENTS + OPTIONAL_ARGUMENTS
+        ]:
+            ForwardModelStepWarning.warn(
+                f"CIRRUS does not recognise the following arguments {', '.join(unrecognised_arguments)}, they can be completely removed"
+            )
+
+        version_idx = fm_step_json["argList"].index("-v") + 1
         requested_version = fm_step_json["argList"][version_idx]
-        self.version_path = Path(f"{ self.VERSIONLOCATION}/{requested_version}")
+        self.version_path = Path(f"{self.VERSIONLOCATION}/{requested_version}")
 
         if not self.version_path.exists():
-
             available_versions = [
                 f for f in os.listdir(self.VERSIONLOCATION) if not f.startswith(".")
             ]
@@ -60,7 +88,6 @@ class Cirrus(ForwardModelStepPlugin):
     def validate_pre_realization_run(
         self, fm_step_json: ForwardModelStepJSON
     ) -> ForwardModelStepJSON:
-
         # Version has already been validated, we only need to ensure it is used
         version_idx = fm_step_json["argList"].index("-v") + 1
         fm_step_json["argList"][version_idx] = self.version_path.resolve().name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,9 +20,7 @@ def pytest_collection_modifyitems(config, items):
     if config.getoption("--uses-cirrus"):
         # Do not skip tests when --ert-integration is supplied on pytest command line
         return
-    skip_uses_cirrus = pytest.mark.skip(
-        reason="need --uses-cirrus option to run"
-    )
+    skip_uses_cirrus = pytest.mark.skip(reason="need --uses-cirrus option to run")
     for item in items:
         if "uses_cirrus" in item.keywords:
             item.add_marker(skip_uses_cirrus)

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -3,12 +3,14 @@ import pytest
 import subprocess
 
 from ert.plugins import ErtPluginManager
+from ert.config import ErtConfig
+from ert.config.parsing.config_errors import ConfigValidationError
 
 from ccsfm.forward_models.run_cirrus import Cirrus
 
 DEFAULT_CONFIG = """
 JOBNAME TEST
-
+NUM_CPU 1
 QUEUE_SYSTEM LOCAL
 QUEUE_OPTION LOCAL MAX_RUNNING 1
 
@@ -23,6 +25,22 @@ FORWARD_MODEL {}({})
 def test_forward_model_installation():
     pm = ErtPluginManager()
     assert Cirrus in pm.forward_model_steps
+
+
+@pytest.mark.parametrize(
+    "call_content,expected_failure",
+    [
+        pytest.param("<NUM_CPU>=1, <VERSION>=1", "It is not allowed to modify"),
+        pytest.param("<VERSION>=1, <INCORRECT>=1", "Missing required arguments"),
+    ],
+)
+def test_parameter_validation(call_content, expected_failure):
+    config = DEFAULT_CONFIG.format("CIRRUS", call_content)
+    with open("config.ert", "w", encoding="utf-8") as file:
+        file.write(config)
+
+    with pytest.raises(ConfigValidationError, match=expected_failure):
+        ErtConfig.with_plugins().from_file("config.ert")
 
 
 @pytest.mark.uses_cirrus


### PR DESCRIPTION
a bit difficult testing the working conditions, as the plugin validation relies on an existing installation of cirrus.