### PR TITLE
Fix cirrus forward model path resolvement

### DIFF
--- a/src/ccsfm/forward_models/run_cirrus.py
+++ b/src/ccsfm/forward_models/run_cirrus.py
@@ -89,12 +89,16 @@ class Cirrus(ForwardModelStepPlugin):
                 f"Requested Cirrus version: {requested_version}, is not available. Must be one of {available_versions}"
             )
 
+        # Ensure the version path is resolved at the beginning, so that any symlinks are resolved and we guarante that
+        # the same version is used throughout the experiment
+        self.version_path = self.version_path.resolve()
+
     def validate_pre_realization_run(
         self, fm_step_json: ForwardModelStepJSON
     ) -> ForwardModelStepJSON:
         # Version has already been validated, we only need to ensure it is used
         version_idx = fm_step_json["argList"].index("-v") + 1
-        fm_step_json["argList"][version_idx] = self.version_path.resolve().name
+        fm_step_json["argList"][version_idx] = self.version_path.name
 
         return fm_step_json
 

--- a/src/ccsfm/forward_models/run_cirrus.py
+++ b/src/ccsfm/forward_models/run_cirrus.py
@@ -96,6 +96,12 @@ class Cirrus(ForwardModelStepPlugin):
     def validate_pre_realization_run(
         self, fm_step_json: ForwardModelStepJSON
     ) -> ForwardModelStepJSON:
+
+        # When running with Everest, the validate pre experiment has not run, hence
+        # self.version_path is not set. Also argList is potentially empty
+        if self.version_path == Path():
+            return fm_step_json
+
         # Version has already been validated, we only need to ensure it is used
         version_idx = fm_step_json["argList"].index("-v") + 1
         fm_step_json["argList"][version_idx] = self.version_path.name


### PR DESCRIPTION
Ert currently does not run pre realization validation ( https://github.com/equinor/ert/issues/13250 ), but once it does we will be back in business.

Resolves https://github.com/equinor/ccsfm/issues/21 as well, as everest does run it, but it doesn't run the pre experiment validation, hence it malfunctions. We therefore guard the modification and only do it if path as been changed.